### PR TITLE
Update README.md

### DIFF
--- a/sdk/zksync.js/README.md
+++ b/sdk/zksync.js/README.md
@@ -11,5 +11,5 @@ Full reference on how to use the library can be found [here](https://zksync.io/a
 
 ## Changelog
 
-The changelog of the zksync.js is avaliable
+The changelog of the zksync.js is available 
 [here](https://github.com/matter-labs/zksync/blob/master/changelog/js-sdk.md).


### PR DESCRIPTION
There is a typo in the word "available" in the sentence "The changelog of the zksync_rs is avaliable." The correct spelling should be "available," so the corrected sentence is:

"The changelog of the zksync_rs is available here."