### PR TITLE
Update README.md

### DIFF
--- a/core/tests/flamegraph_target/README.md
+++ b/core/tests/flamegraph_target/README.md
@@ -16,8 +16,7 @@ Since the goal is to avoid _everything_ that is not related to the analysis of t
 you are going to analyze requires `async` support, explicitly create the runtime for said code only.
 
 Target code should be written in a manner that stresses component in the most possible way. If your code needs
-initialization, separate it from the actual stressing logic, so that in the resulting flamegraph they will be easily
-distinguishable.
+initialization, separate it from the actual stressing logic, so they can be easily distinguished in the resulting flamegraph.
 
 That being said, the code is just a playground. It is expected to be adjusted to what you need, so it is OK to keep the
 code simple to parameterize with loops, constants, and whatever else helps you achieve representative performance


### PR DESCRIPTION
The phrase "so that in the resulting flamegraph they will be easily distinguishable" might be more clear and concise as: "so they can be easily distinguished in the resulting flamegraph."